### PR TITLE
Optimize AutoContainer for fast initialization; add xml documentation

### DIFF
--- a/Rock.Core/DependencyInjection/AutoContainer.cs
+++ b/Rock.Core/DependencyInjection/AutoContainer.cs
@@ -9,90 +9,130 @@ using Rock.DependencyInjection.Heuristics;
 
 namespace Rock.DependencyInjection
 {
+    /// <summary>
+    /// An implementation of <see cref="IResolver"/> that registers, at constructor-time,
+    /// a collection of object instances. When the <see cref="Get{T}"/> or <see cref="Get"/>
+    /// methods are called, these instances are available to be passed as a constructor
+    /// arguments if the instance satisfies the constructor arg's contract.
+    /// </summary>
     public partial class AutoContainer : IResolver
     {
-        private readonly Lazy<MethodInfo> _getMethod;
+        private const Func<object> _getInstanceFuncNotFound = null;
+
+        private static readonly MethodInfo _genericGetMethod;
+
+        private readonly IEnumerable<object> _instances;
         private readonly ConcurrentDictionary<Type, Func<object>> _bindings;
         private readonly IResolverConstructorSelector _constructorSelector;
 
+        static AutoContainer()
+        {
+            Expression<Func<AutoContainer, int>> expression = container => container.Get<int>();
+            _genericGetMethod = ((MethodCallExpression)expression.Body).Method.GetGenericMethodDefinition();
+        }
+
         private AutoContainer(
+            IEnumerable<object> instances,
             ConcurrentDictionary<Type, Func<object>> bindings,
             IResolverConstructorSelector constructorSelector)
         {
-            _getMethod = new Lazy<MethodInfo>(() => GetType().GetMethod("Get", Type.EmptyTypes));
-            _constructorSelector = constructorSelector;
+            if (instances == null) { throw new ArgumentNullException("instances"); }
+            if (bindings == null) { throw new ArgumentNullException("bindings"); }
+            if (constructorSelector == null) { throw new ArgumentNullException("constructorSelector"); }
+
+            _instances = instances;
             _bindings = bindings;
+            _constructorSelector = constructorSelector;
         }
 
         /// <summary>
-        /// Copy constructor.
+        /// Copy constructor. Initializes an instance of an inheritor of <see cref="AutoContainer"/>
+        /// to have the same values for its private backing fields as <paramref name="parentContainer"/>.
+        /// NOTE: The fields that are copied are the fields defined in in the <see cref="AutoContainer"/>
+        /// class. In other words, fields defined in an inheritor of <see cref="AutoContainer"/> will not
+        /// be copied by this constructor.
         /// </summary>
         protected AutoContainer(AutoContainer parentContainer)
-            : this(parentContainer._bindings, parentContainer._constructorSelector)
+            : this(parentContainer._instances, parentContainer._bindings, parentContainer._constructorSelector)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="AutoContainer"/>, using the
+        /// <paramref name="instances"/> as its registered dependencies. These
+        /// depenendencies will be resolvable by this instance of
+        /// <see cref="AutoContainer"/> via any type that exactly one dependency
+        /// equals, implements, or inherits from. This instance of <see cref="AutoContainer"/>
+        /// will use <see cref="Default.ResolverConstructorSelector"/> internally to determine
+        /// which constructor of an arbitrary type will be selected for invocation when
+        /// <see cref="Get{T}"/> or <see cref="Get"/> methods are called.
+        /// </summary>
+        /// <param name="instances">The objects to use as registered dependencies.</param>
         public AutoContainer(params object[] instances)
             : this(Default.ResolverConstructorSelector, instances)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="AutoContainer"/>, using the
+        /// <paramref name="instances"/> as its registered dependencies. These
+        /// depenendencies will be resolvable by this instance of
+        /// <see cref="AutoContainer"/> via any type that exactly one dependency
+        /// equals, implements, or inherits from. This instance of <see cref="AutoContainer"/>
+        /// will use the <see cref="IResolverConstructorSelector"/> specified by
+        /// <paramref name="constructorSelector"/> internally to determine
+        /// which constructor of an arbitrary type will be selected for invocation when
+        /// <see cref="Get{T}"/> or <see cref="Get"/> methods are called.
+        /// </summary>
+        /// <param name="constructorSelector">The </param>
+        /// <param name="instances"></param>
         public AutoContainer(IResolverConstructorSelector constructorSelector, IEnumerable<object> instances)
-            : this(new ConcurrentDictionary<Type, Func<object>>(), constructorSelector)
+            : this(
+                (instances == null // I don't know why someone specifically provided null for instances...
+                    ? Enumerable.Empty<object>() // ...but whatever, we'll just use an empty list.
+                    : instances.Where(x => x != null)) // Otherwise, be sure to ignore any null values.
+                .ToList(), // Fully evaluate the instances collection to ensure fast enumeration.
+                new ConcurrentDictionary<Type, Func<object>>(),
+                constructorSelector)
         {
-            foreach (var instance in instances.Where(x => x != null))
-            {
-                var localInstance = instance;
-                foreach (var type in GetTypeHierarchy(instance.GetType()))
-                {
-                    if (_bindings.ContainsKey(type))
-                    {
-                        _bindings[type] = null;
-                    }
-                    else
-                    {
-                        _bindings[type] = () => localInstance;
-                    }
-                }
-            }
         }
 
+        /// <summary>
+        /// Returns whether this instance of <see cref="AutoContainer"/> can get an instance of the specified
+        /// type.
+        /// </summary>
+        /// <param name="type">The type to determine whether this instance is able to get an instance of.</param>
+        /// <returns>True, if this instance can get an instance of the specified type. False, otherwise.</returns>
         public virtual bool CanGet(Type type)
         {
-            Func<object> binding;
-            if (_bindings.TryGetValue(type, out binding))
-            {
-                return binding != null;
-            }
-
-            return CanGetConstructor(type);
+            return GetGetInstanceFunc(type) != _getInstanceFuncNotFound;
         }
 
+        /// <summary>
+        /// Gets an instance of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of object to return.</typeparam>
+        /// <returns>An instance of type <typeparamref name="T"/>.</returns>
         public T Get<T>()
         {
             return (T)Get(typeof(T));
         }
 
+        /// <summary>
+        /// Gets an instance of type <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The type of object to return.</param>
+        /// <returns>An instance of type <paramref name="type"/></returns>
         public virtual object Get(Type type)
         {
-            var getInstance =
-                _bindings.GetOrAdd(
-                    type,
-                    t =>
-                    {
-                        ConstructorInfo ctor;
-                        return
-                            _constructorSelector.TryGetConstructor(type, this, out ctor)
-                                ? GetCreateInstanceFunc(ctor)
-                                : null;
-                    });
+            var getInstanceFunc = GetGetInstanceFunc(type);
 
-            if (getInstance == null)
+            if (getInstanceFunc == _getInstanceFuncNotFound)
             {
                 throw new ResolveException("Cannot resolve type: " + type);
             }
 
-            return getInstance();
+            return getInstanceFunc();
         }
 
         IResolver IResolver.MergeWith(IResolver otherContainer)
@@ -100,16 +140,58 @@ namespace Rock.DependencyInjection
             return MergeWith(otherContainer);
         }
 
-        public virtual AutoContainer MergeWith(IResolver otherContainer)
+        /// <summary>
+        /// Returns a new instance of <see cref="AutoContainer"/> that is the result of a merge operation between
+        /// this instance of <see cref="AutoContainer"/> and <paramref name="secondaryResolver"/>.
+        /// </summary>
+        /// <param name="secondaryResolver">A secondary <see cref="IResolver"/>.</param>
+        /// <returns>An instance of <see cref="AutoContainer"/> resulting from the merge operation.</returns>
+        public virtual AutoContainer MergeWith(IResolver secondaryResolver)
         {
-            return new MergedAutoContainer(this, otherContainer);
+            return new MergedAutoContainer(this, secondaryResolver);
         }
 
-        private bool CanGetConstructor(Type type)
+        /// <summary>
+        /// Returns <see cref="_getInstanceFuncNotFound"/> if the type is unresolvable.
+        /// </summary>
+        private Func<object> GetGetInstanceFunc(Type type)
         {
             return
-                type != typeof(object)
-                && _constructorSelector.CanGetConstructor(type, this);
+                _bindings.GetOrAdd(
+                    type,
+                    t =>
+                    {
+                        if (t == typeof(object))
+                        {
+                            return null;
+                        }
+
+                        object instance;
+                        if (TryGetInstance(t, out instance))
+                        {
+                            return () => instance;
+                        }
+
+                        ConstructorInfo constructor;
+                        if (_constructorSelector.TryGetConstructor(t, this, out constructor))
+                        {
+                            return GetCreateInstanceFunc(constructor);
+                        }
+
+                        return _getInstanceFuncNotFound;
+                    });
+        }
+
+        private bool TryGetInstance(Type type, out object instance)
+        {
+            if (_instances.Count(type.IsInstanceOfType) == 1)
+            {
+                instance = _instances.First(type.IsInstanceOfType);
+                return true;
+            }
+
+            instance = null;
+            return false;
         }
 
         private Func<object> GetCreateInstanceFunc(ConstructorInfo ctor)
@@ -138,24 +220,10 @@ namespace Rock.DependencyInjection
                                 CanGet(p.ParameterType)
                                     ? (Expression)Expression.Call(
                                         thisExpression,
-                                        _getMethod.Value.MakeGenericMethod(p.ParameterType))
+                                        _genericGetMethod.MakeGenericMethod(p.ParameterType))
                                     : Expression.Constant(p.DefaultValue, p.ParameterType))));
 
             return createInstanceExpression.Compile();
-        }
-
-        private static IEnumerable<Type> GetTypeHierarchy(Type type)
-        {
-            return GetConcreteHierarchy(type).Concat(type.GetInterfaces());
-        }
-
-        private static IEnumerable<Type> GetConcreteHierarchy(Type type)
-        {
-            while (type != null && type != typeof(object))
-            {
-                yield return type;
-                type = type.BaseType;
-            }
         }
     }
 }

--- a/Rock.Core/DependencyInjection/IResolver.cs
+++ b/Rock.Core/DependencyInjection/IResolver.cs
@@ -2,26 +2,47 @@
 
 namespace Rock.DependencyInjection
 {
+    /// <summary>
+    /// Defines methods for obtaining instances of arbitrary types.
+    /// </summary>
     public interface IResolver
     {
+        /// <summary>
+        /// Returns whether this instance of <see cref="IResolver"/> can get an instance of the specified
+        /// type.
+        /// </summary>
+        /// <param name="type">The type to determine whether this instance is able to get an instance of.</param>
+        /// <returns>True, if this instance can get an instance of the specified type. False, otherwise.</returns>
         bool CanGet(Type type);
+
+        /// <summary>
+        /// Gets an instance of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of object to return.</typeparam>
+        /// <returns>An instance of type <typeparamref name="T"/>.</returns>
         T Get<T>();
+
+        /// <summary>
+        /// Gets an instance of type <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The type of object to return.</param>
+        /// <returns>An instance of type <paramref name="type"/></returns>
         object Get(Type type);
 
         /// <summary>
-        /// Merge this instance of <see cref="IResolver"/> with <paramref name="secondaryResolver"/>. The
-        /// resulting <see cref="IResolver"/> should always try to use this <see cref="IResolver"/> before
-        /// <paramref name="secondaryResolver"/>, recursively. It should set up the relationship such that
-        /// this <see cref="IResolver"/> has access to <paramref name="secondaryResolver"/>, but not the other
-        /// way around - <paramref name="secondaryResolver"/> shouldn't know about this instance of
-        /// <see cref="IResolver"/> or the <see cref="IResolver"/> that is returned by this method.
+        /// Returns a new instance of <see cref="IResolver"/> that is the result of a merge operation between
+        /// this instance of <see cref="IResolver"/> and <paramref name="secondaryResolver"/>.
         /// </summary>
-        /// <param name="secondaryResolver">The secondary <see cref="IResolver"/>.</param>
-        /// <returns>
-        /// An instance of <see cref="IResolver"/> that tries to use this instance of <see cref="IResolver"/>
-        /// first, but, if this instance of <see cref="IResolver"/> is not suitable, then
-        /// <paramref name="secondaryResolver"/> is used.
-        /// </returns>
+        /// <param name="secondaryResolver">A secondary <see cref="IResolver"/>.</param>
+        /// <returns>An instance of <see cref="IResolver"/> resulting from the merge operation.</returns>
+        /// <remarks>
+        /// Implementors of this method should return an instance of <see cref="IResolver"/> that attempts to
+        /// resolve via this instance of <see cref="IResolver"/> before attempting to resolve from
+        /// <paramref name="secondaryResolver"/>, recursively. It should set up the relationship such that
+        /// the resulting <see cref="IResolver"/> has access to <paramref name="secondaryResolver"/>, but not
+        /// the other way around - <paramref name="secondaryResolver"/> shouldn't "know" about this instance 
+        /// of <see cref="IResolver"/> or the <see cref="IResolver"/> that is returned by this method.
+        /// </remarks>
         IResolver MergeWith(IResolver secondaryResolver);
     }
 }


### PR DESCRIPTION
##### AutoContainer Optimization

Instead of eagerly (i.e. in the constructor) creating bindings for every type in a object's inheritance chain, most of which will never be used, create them lazily - when `CanGet(Type)`, `Get(Type)`, or `Get<T>()` are called, and only for the specified type.
##### Documentation

Fully flesh out xml documentation for the `IResolver` and `AutoContainer` types.
