### PR TITLE
Support setting ApplicationId via config

### DIFF
--- a/Rock.Core/AppSettingsApplicationInfo.cs
+++ b/Rock.Core/AppSettingsApplicationInfo.cs
@@ -19,6 +19,7 @@ namespace Rock
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AppSettingsApplicationInfo"/> class.
+        /// The key of the application ID setting will be "Rock.ApplicationId.Current".
         /// </summary>
         public AppSettingsApplicationInfo()
             : this(DefaultApplicationIdKey)

--- a/Rock.Core/AppSettingsApplicationInfo.cs
+++ b/Rock.Core/AppSettingsApplicationInfo.cs
@@ -7,22 +7,36 @@ using System.Threading.Tasks;
 
 namespace Rock
 {
+    /// <summary>
+    /// An implementation of <see cref="IApplicationInfo"/> that uses a config
+    /// file's appSettings section.
+    /// </summary>
     public class AppSettingsApplicationInfo : IApplicationInfo
     {
         private const string DefaultApplicationIdKey = "Rock.ApplicationId.Current";
 
         private readonly string _applicationIdKey;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppSettingsApplicationInfo"/> class.
+        /// </summary>
         public AppSettingsApplicationInfo()
             : this(DefaultApplicationIdKey)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppSettingsApplicationInfo"/> class.
+        /// </summary>
+        /// <param name="applicationIdKey">The key of the application ID setting.</param>
         public AppSettingsApplicationInfo(string applicationIdKey)
         {
             _applicationIdKey = applicationIdKey;
         }
 
+        /// <summary>
+        /// Gets the ID of the current application.
+        /// </summary>
         public string ApplicationId
         {
             get { return ConfigurationManager.AppSettings[_applicationIdKey]; }

--- a/Rock.Core/AppSettingsApplicationInfo.cs
+++ b/Rock.Core/AppSettingsApplicationInfo.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rock
+{
+    public class AppSettingsApplicationInfo : IApplicationInfo
+    {
+        private const string DefaultApplicationIdKey = "Rock.ApplicationId.Current";
+
+        private readonly string _applicationIdKey;
+
+        public AppSettingsApplicationInfo()
+            : this(DefaultApplicationIdKey)
+        {
+        }
+
+        public AppSettingsApplicationInfo(string applicationIdKey)
+        {
+            _applicationIdKey = applicationIdKey;
+        }
+
+        public string ApplicationId
+        {
+            get { return ConfigurationManager.AppSettings[_applicationIdKey]; }
+        }
+    }
+}

--- a/Rock.Core/ApplicationId.cs
+++ b/Rock.Core/ApplicationId.cs
@@ -1,0 +1,14 @@
+﻿using Rock.Defaults.Implementation;
+using System;
+using System.Configuration;
+
+namespace Rock
+{
+    public static class ApplicationId
+    {
+        public static string Current
+        {
+            get { return Default.ApplicationInfo.ApplicationId; }
+        }
+    }
+}

--- a/Rock.Core/ApplicationId.cs
+++ b/Rock.Core/ApplicationId.cs
@@ -4,8 +4,17 @@ using System.Configuration;
 
 namespace Rock
 {
+    /// <summary>
+    /// Provides access to the ID of the current application.
+    /// </summary>
     public static class ApplicationId
     {
+        /// <summary>
+        /// Gets the ID of the current application.
+        /// </summary>
+        /// <remarks>
+        /// This property returns the value of <see cref="Default.ApplicationInfo.ApplicationId"/>.
+        /// </remarks>
         public static string Current
         {
             get { return Default.ApplicationInfo.ApplicationId; }

--- a/Rock.Core/DefaultApplicationInfo.cs
+++ b/Rock.Core/DefaultApplicationInfo.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Rock
+{
+    internal class DefaultApplicationInfo : IApplicationInfo
+    {
+        private readonly Lazy<string> _appId = new Lazy<string>(() =>
+            GetApplicationId(new AppSettingsApplicationInfo())
+            ?? GetApplicationId(new EntryAssemblyApplicationInfo()));
+
+        public string ApplicationId
+        {
+            get { return _appId.Value; }
+        }
+
+        private static string GetApplicationId(IApplicationInfo applicationInfo)
+        {
+            try
+            {
+                return applicationInfo.ApplicationId;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Rock.Core/DefaultApplicationInfo.cs
+++ b/Rock.Core/DefaultApplicationInfo.cs
@@ -6,12 +6,20 @@ using System.Threading.Tasks;
 
 namespace Rock
 {
+    /// <summary>
+    /// The default implementation of <see cref="IApplicationInfo"/>. Attempts to get the
+    /// value from an instance of <see cref="AppSettingsApplicationInfo"/>. If that fails,
+    /// gets the value from an instance of <see cref="EntryAssemblyApplicationInfo"/>.
+    /// </summary>
     internal class DefaultApplicationInfo : IApplicationInfo
     {
         private readonly Lazy<string> _appId = new Lazy<string>(() =>
             GetApplicationId(new AppSettingsApplicationInfo())
             ?? GetApplicationId(new EntryAssemblyApplicationInfo()));
 
+        /// <summary>
+        /// Gets the ID of the current application.
+        /// </summary>
         public string ApplicationId
         {
             get { return _appId.Value; }

--- a/Rock.Core/Defaults/Implementation/Default.ApplicationInfo.cs
+++ b/Rock.Core/Defaults/Implementation/Default.ApplicationInfo.cs
@@ -4,7 +4,7 @@ namespace Rock.Defaults.Implementation
 {
     public static partial class Default
     {
-        private static readonly DefaultHelper<IApplicationInfo> _applicationInfo = new DefaultHelper<IApplicationInfo>(() => new EntryAssemblyApplicationInfo());
+        private static readonly DefaultHelper<IApplicationInfo> _applicationInfo = new DefaultHelper<IApplicationInfo>(() => new DefaultApplicationInfo());
 
         public static IApplicationInfo ApplicationInfo
         {

--- a/Rock.Core/EntryAssemblyApplicationInfo.cs
+++ b/Rock.Core/EntryAssemblyApplicationInfo.cs
@@ -6,6 +6,10 @@ using System.Reflection;
 
 namespace Rock
 {
+    /// <summary>
+    /// An implementation of <see cref="IApplicationInfo"/> that uses the entry
+    /// assembly's name as the ApplicationId.
+    /// </summary>
     public class EntryAssemblyApplicationInfo : IApplicationInfo
     {
         private static readonly IEnumerable<string> _assembliesToIgnore = new[]
@@ -21,6 +25,9 @@ namespace Rock
 
         private readonly Lazy<string> _appId;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntryAssemblyApplicationInfo"/> class.
+        /// </summary>
         public EntryAssemblyApplicationInfo()
         {
             var entryAssembly = new Lazy<Assembly>(GetEntryAssembly);
@@ -52,6 +59,9 @@ namespace Rock
             throw new InvalidOperationException("Unable to determine entry assembly.");
         }
 
+        /// <summary>
+        /// Gets the ID of the current application.
+        /// </summary>
         public string ApplicationId
         {
             get { return _appId.Value; }

--- a/Rock.Core/IApplicationInfo.cs
+++ b/Rock.Core/IApplicationInfo.cs
@@ -1,7 +1,13 @@
 ﻿namespace Rock
 {
+    /// <summary>
+    /// Represents information about an application.
+    /// </summary>
     public interface IApplicationInfo
     {
+        /// <summary>
+        /// Gets the ID of the current application.
+        /// </summary>
         string ApplicationId { get; }
     }
 }

--- a/Rock.Core/Rock.Core.csproj
+++ b/Rock.Core/Rock.Core.csproj
@@ -34,6 +34,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.Composition.Registration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Reflection.Context" />
@@ -45,8 +46,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ApplicationId.cs" />
+    <Compile Include="DefaultApplicationInfo.cs" />
     <Compile Include="Collections\DeepEqualityComparerConfiguration.cs" />
     <Compile Include="Collections\DefaultMemberLocator.cs" />
+    <Compile Include="AppSettingsApplicationInfo.cs" />
     <Compile Include="Configuration\InvalidConfigurationException.cs" />
     <Compile Include="Configuration\XmlSerializerSectionHandler.cs" />
     <Compile Include="Conversion\ConvertFuncFactory.cs" />


### PR DESCRIPTION
- Add static `ApplicationId` class, exposing a `Current` property, which returns `Default.ApplicationInfo.ApplicationId`.
- Add implementations of `IApplicationInfo`:
  - `AppSettingsApplicationInfo`
    - To get the `ApplicationId` from config.
  - `DefaultApplicationInfo`
    - Tries to get the value from an instance of `AppSettingsApplicationInfo`.
    - If that fails, gets the value from an instance of `EntryAssemblyApplicationInfo`.
- Add documentation.

This pull request allows Rock.Core to get its ApplicationId from config. Example config:

```XML
<configuration>
  <appSettings>
    <add key="Rock.ApplicationId.Current" value="200911" />
  </appSettings>
</configuration>
```