### PR TITLE
Add synchronous MailMessage.Send extension method

### DIFF
--- a/Rock.Core.IntegrationTests/Mail/LocalMailServer.cs
+++ b/Rock.Core.IntegrationTests/Mail/LocalMailServer.cs
@@ -31,7 +31,7 @@ namespace Rock.Core.IntegrationTests.Mail
             get { return _server.Port; }
         }
 
-        public Task<string> GetMailData(int timeoutMilliseconds = 30000)
+        public Task<string> GetMailDataAsync(int timeoutMilliseconds = 30000)
         {
             StartTimeoutTimer(timeoutMilliseconds);
 

--- a/Rock.Core/Mail/SendExtension.cs
+++ b/Rock.Core/Mail/SendExtension.cs
@@ -5,13 +5,46 @@ namespace Rock.Mail
 {
     public static class SendExtension
     {
+        /// <summary>
+        /// Asynchronously sends the specified mail message using the specified
+        /// delivery method.
+        /// </summary>
+        /// <param name="mailMessage">The mail message to send.</param>
+        /// <param name="deliveryMethod">
+        /// A object that specifies the delivery method to use. <c>null</c> indicates that
+        /// the default delivery method (as specified in config) will be used.
+        /// </param>
+        /// <returns>A task that completes once the mail message has been delivered.</returns>
         public static async Task SendAsync(this MailMessage mailMessage, DeliveryMethod deliveryMethod = null)
         {
-            using (var smtpClient = new SmtpClient())
+            using (var smtpClient = GetSmtpClient(deliveryMethod))
             {
-                (deliveryMethod ?? DeliveryMethod.Default).ConfigureSmtpClient(smtpClient);
                 await smtpClient.SendMailAsync(mailMessage).ConfigureAwait(false);
             }
+        }
+
+        /// <summary>
+        /// Synchronously sends the specified mail message using the specified
+        /// delivery method.
+        /// </summary>
+        /// <param name="mailMessage">The mail message to send.</param>
+        /// <param name="deliveryMethod">
+        /// A object that specifies the delivery method to use. <c>null</c> indicates that
+        /// the default delivery method (as specified in config) will be used.
+        /// </param>
+        public static void Send(this MailMessage mailMessage, DeliveryMethod deliveryMethod = null)
+        {
+            using (var smtpClient = GetSmtpClient(deliveryMethod))
+            {
+                smtpClient.Send(mailMessage);
+            }
+        }
+
+        private static SmtpClient GetSmtpClient(DeliveryMethod deliveryMethod)
+        {
+            var smtpClient = new SmtpClient();
+            (deliveryMethod ?? DeliveryMethod.Default).ConfigureSmtpClient(smtpClient);
+            return smtpClient;
         }
     }
 }


### PR DESCRIPTION
This PR adds a synchronous `Send` extension method to the `MailMessage` class. Previously, only a `SendAsync` extension method existed. This change will make it easier for applications that have synchronous workflows.