### PR TITLE
Add IProtectedValue interface and some default XML implementations

### DIFF
--- a/Rock.Core.UnitTests/DataProtection/Xml/DPAPIProtectedValueTests.cs
+++ b/Rock.Core.UnitTests/DataProtection/Xml/DPAPIProtectedValueTests.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using NUnit.Framework;
+using Rock.DataProtection.Xml;
+
+namespace Rock.Core.UnitTests.DataProtection.Xml
+{
+    public class DPAPIProtectedValueTests
+    {
+        [Test]
+        public void CannotPassNullToTheByteArrayConstructor()
+        {
+            Assert.That(() => new DPAPIProtectedValue((IList<byte>)null), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void CannotPassNullToTheStringConstructor()
+        {
+            Assert.That(() => new DPAPIProtectedValue((string)null), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void CannotPassNonBase64EncodedStringToTheStringConstructor()
+        {
+            Assert.That(() => new DPAPIProtectedValue("wtf"), Throws.TypeOf<FormatException>());
+        }
+
+        [Test]
+        public void CanPassBase64EncodedStringToTheStringConstructor()
+        {
+            Assert.That(() => new DPAPIProtectedValue(Convert.ToBase64String(new byte[] { 1, 2, 3 })), Throws.Nothing);
+        }
+
+        [Test]
+        public void TheEncryptedDataByteArrayPassedToTheByteArrayConstructorIsReturnedByTheEncryptedDataProperty()
+        {
+            var encryptedData = new byte[] { 1, 2, 3 };
+
+            var value = new DPAPIProtectedValue(encryptedData);
+
+            Assert.That(value.EncryptedData, Is.EqualTo(encryptedData));
+        }
+
+        [Test]
+        public void TheEncryptedDataBase64EncodedStringPassedToTheStringConstructorIsDecodedAndReturnedByTheEncryptedDataProperty()
+        {
+            var encryptedDataBytes = new byte[] { 1, 2, 3 };
+            var encryptedData = Convert.ToBase64String(encryptedDataBytes);
+
+            var value = new DPAPIProtectedValue(encryptedData);
+
+            Assert.That(value.EncryptedData, Is.EqualTo(encryptedDataBytes));
+        }
+
+        [Test]
+        public void TheOptionalEntropyByteArrayPassedToTheByteArrayConstructorIsReturnedByTheOptionalEntropyProperty()
+        {
+            var encryptedData = new byte[] { 1, 2, 3 };
+            var optionalEntropy = new byte[] { 4, 5, 6 };
+
+            var value = new DPAPIProtectedValue(encryptedData, optionalEntropy);
+
+            Assert.That(value.OptionalEntropy, Is.EqualTo(optionalEntropy));
+        }
+
+        [Test]
+        public void TheOptionalEntropyBase64EncodedStringPassedToTheStringConstructorIsDecodedAndReturnedByTheOptionalEntropyProperty()
+        {
+            var encryptedDataBytes = new byte[] { 1, 2, 3 };
+            var optionalEntropyBytes = new byte[] { 4, 5, 6 };
+            var encryptedData = Convert.ToBase64String(encryptedDataBytes);
+            var optionalEntropy = Convert.ToBase64String(optionalEntropyBytes);
+
+            var value = new DPAPIProtectedValue(encryptedData, optionalEntropy);
+
+            Assert.That(value.OptionalEntropy, Is.EqualTo(optionalEntropyBytes));
+        }
+
+        [Test]
+        public void TheScopePassedToTheByteArrayConstructorIsReturnedByTheScopeProperty()
+        {
+            var encryptedData = new byte[] { 1, 2, 3 };
+
+            var value = new DPAPIProtectedValue(encryptedData, scope:DataProtectionScope.LocalMachine);
+
+            Assert.That(value.Scope, Is.EqualTo(DataProtectionScope.LocalMachine));
+        }
+
+        [Test]
+        public void TheScopePassedToTheStringConstructorIsReturnedByTheScopeProperty()
+        {
+            var encryptedDataBytes = new byte[] { 1, 2, 3 };
+            var encryptedData = Convert.ToBase64String(encryptedDataBytes);
+
+            var value = new DPAPIProtectedValue(encryptedData, scope:DataProtectionScope.LocalMachine);
+
+            Assert.That(value.Scope, Is.EqualTo(DataProtectionScope.LocalMachine));
+        }
+
+        [Test]
+        public void CanUnprotectDPAPIProtectedValue()
+        {
+            var userData = Encoding.UTF8.GetBytes("Hello, world!");
+            var optionalEntropy = new byte[] { 4, 5, 6 };
+            var scope = DataProtectionScope.LocalMachine;
+
+            var encryptedData = ProtectedData.Protect(userData, optionalEntropy, scope);
+
+            Assume.That(encryptedData, Is.Not.EqualTo(userData));
+
+            var protectedValue = new DPAPIProtectedValue(encryptedData, optionalEntropy, scope);
+
+            var unprotectedValue = protectedValue.GetValue();
+
+            Assert.That(Encoding.UTF8.GetString(unprotectedValue), Is.EqualTo("Hello, world!"));
+        }
+
+        [Test]
+        public void CanUnprotectDPAPIProtectedValueWhenNoOptionalEntropyIsProvided()
+        {
+            var userData = Encoding.UTF8.GetBytes("Hello, world!");
+            var scope = DataProtectionScope.LocalMachine;
+
+            var encryptedData = ProtectedData.Protect(userData, null, scope);
+
+            Assume.That(encryptedData, Is.Not.EqualTo(userData));
+
+            var protectedValue = new DPAPIProtectedValue(encryptedData, scope:scope);
+
+            var unprotectedValue = protectedValue.GetValue();
+
+            Assert.That(Encoding.UTF8.GetString(unprotectedValue), Is.EqualTo("Hello, world!"));
+        }
+
+        [Test]
+        public void CanUnprotectDPAPIProtectedValueWhenNoScopeIsProvided()
+        {
+            var userData = Encoding.UTF8.GetBytes("Hello, world!");
+            var optionalEntropy = new byte[] { 4, 5, 6 };
+
+            var encryptedData = ProtectedData.Protect(userData, optionalEntropy, DataProtectionScope.CurrentUser);
+
+            Assume.That(encryptedData, Is.Not.EqualTo(userData));
+
+            var protectedValue = new DPAPIProtectedValue(encryptedData, optionalEntropy);
+
+            var unprotectedValue = protectedValue.GetValue();
+
+            Assert.That(Encoding.UTF8.GetString(unprotectedValue), Is.EqualTo("Hello, world!"));
+        }
+
+        [Test]
+        public void CannotUnprotectGarbage()
+        {
+            var garbage = new byte[] { 1, 2, 3, 4, 5, 6 };
+
+            var protectedValue = new DPAPIProtectedValue(garbage);
+
+            Assert.That(() => protectedValue.GetValue(), Throws.TypeOf<CryptographicException>());
+        }
+    }
+}

--- a/Rock.Core.UnitTests/DataProtection/Xml/ProtectedValueProxyTests.cs
+++ b/Rock.Core.UnitTests/DataProtection/Xml/ProtectedValueProxyTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml.Serialization;
+using NUnit.Framework;
+using Rock.DataProtection.Xml;
+
+namespace Rock.Core.UnitTests.DataProtection.Xml
+{
+    public class ProtectedValueProxyTests
+    {
+        [Test]
+        public void TheDefaultTypeIsUnprotected()
+        {
+            var value = Encoding.UTF8.GetBytes("Hello, world!");
+            var xml = string.Format("<Foo><Bar value=\"{0}\" /></Foo>", Convert.ToBase64String(value));
+            var foo = (Foo)new XmlSerializer(typeof(Foo)).Deserialize(new StringReader(xml));
+
+            var bar = foo.Bar.CreateInstance();
+            
+            Assert.That(bar, Is.InstanceOf<UnprotectedValue>());
+            Assert.That(bar.GetValue(), Is.EqualTo(value));
+        }
+
+        [Test]
+        public void DPAPIProtectedValueCanBeSpecified()
+        {
+            var value = Encoding.UTF8.GetBytes("Hello, world!");
+            var optionalEntropy = new byte[] { 1, 2, 3, 4, 5, 6 };
+            var encryptedData = ProtectedData.Protect(value, optionalEntropy, DataProtectionScope.CurrentUser);
+            var xml = string.Format(
+@"<Foo>
+  <Bar type=""Rock.DataProtection.Xml.DPAPIProtectedValue, Rock.Core""
+       encryptedData=""{0}""
+       optionalEntropy=""{1}""
+       scope=""CurrentUser"" />
+</Foo>",
+                Convert.ToBase64String(encryptedData),
+                Convert.ToBase64String(optionalEntropy));
+            var foo = (Foo)new XmlSerializer(typeof(Foo)).Deserialize(new StringReader(xml));
+            
+            var bar = foo.Bar.CreateInstance();
+            
+            Assert.That(bar, Is.InstanceOf<DPAPIProtectedValue>());
+            Assert.That(bar.GetValue(), Is.EqualTo(value));
+        }
+
+        public class Foo
+        {
+            public ProtectedValueProxy Bar { get; set; }
+        }
+    }
+}

--- a/Rock.Core.UnitTests/DataProtection/Xml/UnprotectedValueTests.cs
+++ b/Rock.Core.UnitTests/DataProtection/Xml/UnprotectedValueTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Rock.DataProtection;
+using Rock.DataProtection.Xml;
+
+namespace Rock.Core.UnitTests.DataProtection.Xml
+{
+    public class UnprotectedValueTests
+    {
+        [Test]
+        public void CannotPassNullToByteArrayConstructor()
+        {
+            Assert.That(() => new UnprotectedValue((IList<byte>)null), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void CannotPassNullToStringConstructor()
+        {
+            Assert.That(() => new UnprotectedValue((string)null), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void CannotPassNonBase64EncodedStringToStringConstructor()
+        {
+            Assert.That(() => new UnprotectedValue("wtf"), Throws.TypeOf<FormatException>());
+        }
+
+        [Test]
+        public void CanPassBase64EncodedStringToStringConstructor()
+        {
+            Assert.That(() => new UnprotectedValue(Convert.ToBase64String(new byte[] { 1, 2, 3 })), Throws.Nothing);
+        }
+
+        [Test]
+        public void TheByteArrayPassedToTheByteArrayConstructorIsReturnedByGetValueMethod()
+        {
+            var data = new byte[] { 1, 2, 3 };
+
+            IProtectedValue value = new UnprotectedValue(data);
+
+            Assert.That(value.GetValue(), Is.EqualTo(data));
+        }
+
+        [Test]
+        public void TheBase64EncodedStringPassedToTheStringConstructorIsDecodedAndReturnedByGetValueMethod()
+        {
+            var data = new byte[] { 1, 2, 3 };
+            var stringData = Convert.ToBase64String(data);
+
+            IProtectedValue value = new UnprotectedValue(stringData);
+
+            Assert.That(value.GetValue(), Is.EqualTo(data));
+        }
+    }
+}

--- a/Rock.Core.UnitTests/Rock.Core.UnitTests.csproj
+++ b/Rock.Core.UnitTests/Rock.Core.UnitTests.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -55,6 +56,9 @@
     <Compile Include="Compression\CompressionTests.cs" />
     <Compile Include="Conversion\ConvertFuncFactoryTests.cs" />
     <Compile Include="Conversion\ConvertsToDictionaryOfStringToTValueTests.cs" />
+    <Compile Include="DataProtection\Xml\DPAPIProtectedValueTests.cs" />
+    <Compile Include="DataProtection\Xml\ProtectedValueProxyTests.cs" />
+    <Compile Include="DataProtection\Xml\UnprotectedValueTests.cs" />
     <Compile Include="Extensions\StringExtensionsTest.cs" />
     <Compile Include="Extensions\TemporalExtensions.cs" />
     <Compile Include="Reflection\GetClosedGenericTypeExtensionTests.cs" />

--- a/Rock.Core.sln.DotSettings
+++ b/Rock.Core.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DPAPI/@EntryIndexedValue">DPAPI</s:String></wpf:ResourceDictionary>

--- a/Rock.Core/DataProtection/IProtectedValue.cs
+++ b/Rock.Core/DataProtection/IProtectedValue.cs
@@ -1,0 +1,14 @@
+﻿namespace Rock.DataProtection
+{
+    /// <summary>
+    /// Defines an interface for encapsulating sensitive data.
+    /// </summary>
+    public interface IProtectedValue
+    {
+        /// <summary>
+        /// Gets the plain text value.
+        /// </summary>
+        /// <returns></returns>
+        byte[] GetValue();
+    }
+}

--- a/Rock.Core/DataProtection/Xml/DPAPIProtectedValue.cs
+++ b/Rock.Core/DataProtection/Xml/DPAPIProtectedValue.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Rock.DataProtection.Xml
+{
+    /// <summary>
+    /// An implementation of <see cref="IProtectedValue"/> that stores the sensitive
+    /// data using DPAPI.
+    /// </summary>
+    public class DPAPIProtectedValue : IProtectedValue
+    {
+        private readonly DataProtectionScope _scope;
+        private readonly ReadOnlyCollection<byte> _encryptedData;
+        private readonly ReadOnlyCollection<byte> _optionalEntropy;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DPAPIProtectedValue"/> class.
+        /// </summary>
+        /// <param name="encryptedData">
+        /// A byte array containing data encrypted using the
+        /// <see cref="ProtectedData.Protect"/> method.
+        /// </param>
+        /// <param name="optionalEntropy">
+        /// An optional additional byte array that was used to encrypt the data, or
+        /// null if the additional byte array was not used.
+        /// </param>
+        /// <param name="scope">
+        /// One of the enumeration values that specifies the scope of data protection
+        /// that was used to encrypt the data.
+        /// </param>
+        public DPAPIProtectedValue(IList<byte> encryptedData, IList<byte> optionalEntropy = null,
+            DataProtectionScope scope = DataProtectionScope.CurrentUser)
+        {
+            if (encryptedData == null) throw new ArgumentNullException("encryptedData");
+            _scope = scope;
+            _encryptedData = new ReadOnlyCollection<byte>(encryptedData);
+            _optionalEntropy = optionalEntropy == null ? null : new ReadOnlyCollection<byte>(optionalEntropy);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DPAPIProtectedValue"/> class.
+        /// </summary>
+        /// <param name="encryptedData">
+        /// A base-64 encoded byte array containing data encrypted using the
+        /// <see cref="ProtectedData.Protect"/> method.
+        /// </param>
+        /// <param name="optionalEntropy">
+        /// An optional additional base-64 encoded byte array that was used to encrypt
+        /// the data, or null if the additional byte array was not used.
+        /// </param>
+        /// <param name="scope">
+        /// One of the enumeration values that specifies the scope of data protection
+        /// that was used to encrypt the data.
+        /// </param>
+        public DPAPIProtectedValue(string encryptedData, string optionalEntropy = null,
+            DataProtectionScope scope = DataProtectionScope.CurrentUser)
+        {
+            if (encryptedData == null) throw new ArgumentNullException("encryptedData");
+            _scope = scope;
+            _encryptedData = new ReadOnlyCollection<byte>(Convert.FromBase64String(encryptedData));
+            _optionalEntropy = optionalEntropy == null ? null : new ReadOnlyCollection<byte>(Convert.FromBase64String(optionalEntropy));
+        }
+
+        /// <summary>
+        /// Gets a base-64 encoded byte array containing data encrypted using the
+        /// <see cref="ProtectedData.Protect"/> method.
+        /// </summary>
+        public IReadOnlyList<byte> EncryptedData { get { return _encryptedData; } }
+
+        /// <summary>
+        /// Gets an optional additional base-64 encoded byte array that was used to encrypt
+        /// the data, or null if the additional byte array was not used.
+        /// </summary>
+        public IReadOnlyList<byte> OptionalEntropy { get { return _optionalEntropy; } }
+
+        /// <summary>
+        /// Gets one of the enumeration values that specifies the scope of data protection
+        /// that was used to encrypt the data.
+        /// </summary>
+        public DataProtectionScope Scope { get { return _scope; } }
+
+        /// <summary>
+        /// Gets the plain text value.
+        /// </summary>
+        /// <returns>The plain text value.</returns>
+        public byte[] GetValue()
+        {
+            var optionalEntropy = _optionalEntropy == null
+                ? null
+                : _optionalEntropy.ToArray();
+
+            var plainText = ProtectedData.Unprotect(
+                _encryptedData.ToArray(), optionalEntropy, _scope);
+
+            return plainText;
+        } 
+    }
+}

--- a/Rock.Core/DataProtection/Xml/ProtectedValueProxy.cs
+++ b/Rock.Core/DataProtection/Xml/ProtectedValueProxy.cs
@@ -1,0 +1,18 @@
+﻿using Rock.Serialization;
+
+namespace Rock.DataProtection.Xml
+{
+    /// <summary>
+    /// A class that creates instances of <see cref="IProtectedValue"/>.
+    /// </summary>
+    public class ProtectedValueProxy : XmlDeserializationProxy<IProtectedValue>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtectedValueProxy"/> class.
+        /// </summary>
+        public ProtectedValueProxy()
+            : base(typeof(UnprotectedValue))
+        {
+        }
+    }
+}

--- a/Rock.Core/DataProtection/Xml/UnprotectedValue.cs
+++ b/Rock.Core/DataProtection/Xml/UnprotectedValue.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Rock.DataProtection.Xml
+{
+    /// <summary>
+    /// An implementation of <see cref="IProtectedValue"/> that stores the sensitive
+    /// data as plain text.
+    /// </summary>
+    public class UnprotectedValue : IProtectedValue
+    {
+        private readonly ReadOnlyCollection<byte> _value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnprotectedValue"/> class.
+        /// </summary>
+        /// <param name="value">The plain text byte array value.</param>
+        public UnprotectedValue(IList<byte> value)
+        {
+            if (value == null) throw new ArgumentNullException("value");
+            _value = new ReadOnlyCollection<byte>(value);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnprotectedValue"/> class.
+        /// </summary>
+        /// <param name="value">The base-64 encoded plain text byte array value.</param>
+        public UnprotectedValue(string value)
+        {
+            if (value == null) throw new ArgumentNullException("value");
+            _value = new ReadOnlyCollection<byte>(Convert.FromBase64String(value));
+        }
+        
+        /// <summary>
+        /// Gets the plain text value.
+        /// </summary>
+        public IReadOnlyList<byte> Value { get { return _value; } }
+
+        /// <summary>
+        /// Gets the plain text value.
+        /// </summary>
+        /// <returns>The plain text value.</returns>
+        public byte[] GetValue()
+        {
+            return _value.ToArray();
+        } 
+    }
+}

--- a/Rock.Core/Rock.Core.csproj
+++ b/Rock.Core/Rock.Core.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Reflection.Context" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -65,6 +66,10 @@
     <Compile Include="Configuration\LateBoundConfigurationElement.cs" />
     <Compile Include="Cryptography\HashType.cs" />
     <Compile Include="Cryptography\HashTypeExtensions.cs" />
+    <Compile Include="DataProtection\Xml\DPAPIProtectedValue.cs" />
+    <Compile Include="DataProtection\IProtectedValue.cs" />
+    <Compile Include="DataProtection\Xml\ProtectedValueProxy.cs" />
+    <Compile Include="DataProtection\Xml\UnprotectedValue.cs" />
     <Compile Include="DefaultApplicationIdProvider.cs" />
     <Compile Include="Collections\DeepEqualityComparerConfiguration.cs" />
     <Compile Include="Collections\MemberLocator.cs" />


### PR DESCRIPTION
This allows regular xml deserialization to automatically read a protected (encrypted) value and present it as plain text.