### PR TITLE
Nested proxy bug

### DIFF
--- a/Rock.Core/Serialization/XmlDeserializationProxyEngine.cs
+++ b/Rock.Core/Serialization/XmlDeserializationProxyEngine.cs
@@ -467,8 +467,15 @@ namespace Rock.Serialization
 
                         if (typeFromAttribute != null)
                         {
-                            serializer = new XmlSerializer(typeFromAttribute,
-                                new XmlRootAttribute(additionalElement.Name.LocalName));
+                            try
+                            {
+                                serializer = new XmlSerializer(typeFromAttribute,
+                                    new XmlRootAttribute(additionalElement.Name.LocalName));
+                            }
+                            catch (InvalidOperationException)
+                            {
+                                serializer = null;
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fix bug where a concrete type that was created with a deserialization proxy contains a deserialization proxy property and the type is specified for that nested proxy.