### PR TITLE
Throw better exceptions from DPAPIProtectedValue

### DIFF
--- a/Rock.Core/DataProtection/DataProtectionException.cs
+++ b/Rock.Core/DataProtection/DataProtectionException.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace Rock.DataProtection
+{
+    /// <summary>
+    /// Represents errors that occur during a data protection operation.
+    /// </summary>
+    public class DataProtectionException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataProtectionException"/>
+        /// class.
+        /// </summary>
+        public DataProtectionException()
+            : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataProtectionException"/>
+        /// class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public DataProtectionException(string message)
+            : base(message) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DataProtectionException"/>
+        /// class with a specified error message and a reference to the inner exception
+        /// that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception, or a null reference
+        /// (Nothing in Visual Basic) if no inner exception is specified.
+        /// </param>
+        public DataProtectionException(string message, Exception innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/Rock.Core/DataProtection/IProtectedValue.cs
+++ b/Rock.Core/DataProtection/IProtectedValue.cs
@@ -8,7 +8,11 @@
         /// <summary>
         /// Gets the plain text value.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The plain text value</returns>
+        /// <exception cref="DataProtectionException">
+        /// Implementors of <see cref="IProtectedValue"/> should throw a <see cref="DataProtectionException"/>
+        /// when they unable to retrieve a plain text value from its source.
+        /// </exception>
         byte[] GetValue();
     }
 }

--- a/Rock.Core/DataProtection/Xml/DPAPIProtectedValue.cs
+++ b/Rock.Core/DataProtection/Xml/DPAPIProtectedValue.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Security;
 using System.Security.Cryptography;
 
 namespace Rock.DataProtection.Xml
@@ -13,8 +14,8 @@ namespace Rock.DataProtection.Xml
     public class DPAPIProtectedValue : IProtectedValue
     {
         private readonly DataProtectionScope _scope;
-        private readonly ReadOnlyCollection<byte> _encryptedData;
-        private readonly ReadOnlyCollection<byte> _optionalEntropy;
+        private readonly Lazy<ReadOnlyCollection<byte>> _encryptedData;
+        private readonly Lazy<ReadOnlyCollection<byte>> _optionalEntropy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DPAPIProtectedValue"/> class.
@@ -34,10 +35,17 @@ namespace Rock.DataProtection.Xml
         public DPAPIProtectedValue(IList<byte> encryptedData, IList<byte> optionalEntropy = null,
             DataProtectionScope scope = DataProtectionScope.CurrentUser)
         {
-            if (encryptedData == null) throw new ArgumentNullException("encryptedData");
             _scope = scope;
-            _encryptedData = new ReadOnlyCollection<byte>(encryptedData);
-            _optionalEntropy = optionalEntropy == null ? null : new ReadOnlyCollection<byte>(optionalEntropy);
+            _encryptedData = new Lazy<ReadOnlyCollection<byte>>(() =>
+            {
+                if (encryptedData == null) throw new ArgumentNullException("encryptedData");
+                var readOnlyEncryptedData = new ReadOnlyCollection<byte>(encryptedData);
+                return readOnlyEncryptedData;
+            });
+            _optionalEntropy = new Lazy<ReadOnlyCollection<byte>>(() =>
+                optionalEntropy == null
+                    ? null
+                    : new ReadOnlyCollection<byte>(optionalEntropy));
         }
 
         /// <summary>
@@ -58,23 +66,31 @@ namespace Rock.DataProtection.Xml
         public DPAPIProtectedValue(string encryptedData, string optionalEntropy = null,
             DataProtectionScope scope = DataProtectionScope.CurrentUser)
         {
-            if (encryptedData == null) throw new ArgumentNullException("encryptedData");
             _scope = scope;
-            _encryptedData = new ReadOnlyCollection<byte>(Convert.FromBase64String(encryptedData));
-            _optionalEntropy = optionalEntropy == null ? null : new ReadOnlyCollection<byte>(Convert.FromBase64String(optionalEntropy));
+            _encryptedData = new Lazy<ReadOnlyCollection<byte>>(() =>
+            {
+                if (encryptedData == null) throw new ArgumentNullException("encryptedData");
+                var data = Convert.FromBase64String(encryptedData);
+                var readOnlyEncryptedData = new ReadOnlyCollection<byte>(data);
+                return readOnlyEncryptedData;
+            });
+            _optionalEntropy = new Lazy<ReadOnlyCollection<byte>>(() =>
+                optionalEntropy == null
+                    ? null
+                    : new ReadOnlyCollection<byte>(Convert.FromBase64String(optionalEntropy)));
         }
 
         /// <summary>
         /// Gets a base-64 encoded byte array containing data encrypted using the
         /// <see cref="ProtectedData.Protect"/> method.
         /// </summary>
-        public IReadOnlyList<byte> EncryptedData { get { return _encryptedData; } }
+        public IReadOnlyList<byte> EncryptedData { get { return _encryptedData.Value; } }
 
         /// <summary>
         /// Gets an optional additional base-64 encoded byte array that was used to encrypt
         /// the data, or null if the additional byte array was not used.
         /// </summary>
-        public IReadOnlyList<byte> OptionalEntropy { get { return _optionalEntropy; } }
+        public IReadOnlyList<byte> OptionalEntropy { get { return _optionalEntropy.Value; } }
 
         /// <summary>
         /// Gets one of the enumeration values that specifies the scope of data protection
@@ -88,14 +104,39 @@ namespace Rock.DataProtection.Xml
         /// <returns>The plain text value.</returns>
         public byte[] GetValue()
         {
-            var optionalEntropy = _optionalEntropy == null
-                ? null
-                : _optionalEntropy.ToArray();
+            byte[] optionalEntropy;
+            try
+            {
+                optionalEntropy = _optionalEntropy.Value == null
+                    ? null
+                    : _optionalEntropy.Value.ToArray();
+            }
+            catch (FormatException ex)
+            {
+                throw new DataProtectionException("The value for the 'optionalEntropy' string, when provided, must be a valid base-64 encoded string.", ex);
+            }
+            try
+            {
+                var plainText = ProtectedData.Unprotect(
+                    _encryptedData.Value.ToArray(), optionalEntropy, _scope);
+                return plainText;
+            }
+            catch (ArgumentNullException ex) { throw new DataProtectionException("No value was provided for 'encryptedData'.", ex); }
+            catch (FormatException ex) { throw new DataProtectionException("The value for 'encryptedData' was not a valid base-64 encoded string.", ex); }
+            catch (SecurityException ex) { throw GetException(ex); }
+            catch (CryptographicException ex) { throw GetException(ex); }
+            catch (Exception ex) { throw new DataProtectionException("An unexpected exception occurred.", ex); }
+        }
 
-            var plainText = ProtectedData.Unprotect(
-                _encryptedData.ToArray(), optionalEntropy, _scope);
+        private DataProtectionException GetException(Exception ex)
+        {
+            var message = $@"Error while unprotecting DPAPI-protected user data. {
+                (Scope == DataProtectionScope.CurrentUser
+                    ? "The scope is set to 'CurrentUser' - are you sure that the user that is running this application is the same user that protected the user data?"
+                    : "The scope is set to 'LocalMachine' - are you sure that the machine that is running this application is the same machine that was used to protect the user data?")}";
 
-            return plainText;
-        } 
+            var exception = new DataProtectionException(message, ex);
+            return exception;
+        }
     }
 }

--- a/Rock.Core/Rock.Core.csproj
+++ b/Rock.Core/Rock.Core.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Configuration\LateBoundConfigurationElement.cs" />
     <Compile Include="Cryptography\HashType.cs" />
     <Compile Include="Cryptography\HashTypeExtensions.cs" />
+    <Compile Include="DataProtection\DataProtectionException.cs" />
     <Compile Include="DataProtection\Xml\DPAPIProtectedValue.cs" />
     <Compile Include="DataProtection\IProtectedValue.cs" />
     <Compile Include="DataProtection\Xml\ProtectedValueProxy.cs" />


### PR DESCRIPTION
When something goes wrong, `DPAPIProtectedValue` throws the new exception, `DataProtectionException`.