### PR TITLE
Semimutable bug fix

### DIFF
--- a/Rock.Core/BackgroundErrorLogging/BackgroundErrorLogger.cs
+++ b/Rock.Core/BackgroundErrorLogging/BackgroundErrorLogger.cs
@@ -43,12 +43,12 @@ namespace Rock.BackgroundErrorLogging
 
         internal static void UnlockCurrent()
         {
-            _current.UnlockValue();
+            _current.GetUnlockValueMethod().Invoke(_current, null);
         }
 
         internal static void UnlockBackgroundErrorLogFactory()
         {
-            _backgroundErrorLogFactory.UnlockValue();
+            _backgroundErrorLogFactory.GetUnlockValueMethod().Invoke(_backgroundErrorLogFactory, null);
         }
 
         private static IBackgroundErrorLogger GetDefaultBackgroundErrorLogger()

--- a/Rock.Core/BackgroundErrorLogging/BackgroundErrorLogger.cs
+++ b/Rock.Core/BackgroundErrorLogging/BackgroundErrorLogger.cs
@@ -11,8 +11,8 @@ namespace Rock.BackgroundErrorLogging
     /// </summary>
     public static class BackgroundErrorLogger
     {
-        private static readonly Semimutable<IBackgroundErrorLogger> _current = new Semimutable<IBackgroundErrorLogger>(GetDefaultBackgroundErrorLogger, true);
-        private static readonly Semimutable<IBackgroundErrorLogFactory> _backgroundErrorLogFactory = new Semimutable<IBackgroundErrorLogFactory>(new BackgroundErrorLogFactory(CreateDefaultBackgroundErrorLog), true);
+        private static readonly Semimutable<IBackgroundErrorLogger> _current = new Semimutable<IBackgroundErrorLogger>(GetDefaultBackgroundErrorLogger);
+        private static readonly Semimutable<IBackgroundErrorLogFactory> _backgroundErrorLogFactory = new Semimutable<IBackgroundErrorLogFactory>(new BackgroundErrorLogFactory(CreateDefaultBackgroundErrorLog));
 
         /// <summary>
         /// Gets the current <see cref="IBackgroundErrorLogger"/>.

--- a/Rock.Core/Conversion/ToDictionaryOfStringToStringExtension.cs
+++ b/Rock.Core/Conversion/ToDictionaryOfStringToStringExtension.cs
@@ -30,7 +30,7 @@ namespace Rock.Conversion
 
         internal static void UnlockConverter()
         {
-            _converter.UnlockValue();
+            _converter.GetUnlockValueMethod().Invoke(_converter, null);
         }
 
         private static IConvertsTo<IDictionary<string, string>> GetDefaultConverter()

--- a/Rock.Core/Conversion/ToExpandoObjectExtension.cs
+++ b/Rock.Core/Conversion/ToExpandoObjectExtension.cs
@@ -30,7 +30,7 @@ namespace Rock.Conversion
 
         internal static void UnlockConverter()
         {
-            _converter.UnlockValue();
+            _converter.GetUnlockValueMethod().Invoke(_converter, null);
         }
 
         private static IConvertsTo<ExpandoObject> GetDefaultConverter()

--- a/Rock.Core/Conversion/ToExpandoObjectExtension.cs
+++ b/Rock.Core/Conversion/ToExpandoObjectExtension.cs
@@ -5,7 +5,7 @@ namespace Rock.Conversion
 {
     public static class ToExpandoObjectExtension
     {
-        private static readonly Semimutable<IConvertsTo<ExpandoObject>> _converter = new Semimutable<IConvertsTo<ExpandoObject>>(GetDefaultConverter, true);
+        private static readonly Semimutable<IConvertsTo<ExpandoObject>> _converter = new Semimutable<IConvertsTo<ExpandoObject>>(GetDefaultConverter);
 
         public static ExpandoObject ToExpandoObject(this object obj)
         {

--- a/Rock.Core/DependencyInjection/AutoContainer.cs
+++ b/Rock.Core/DependencyInjection/AutoContainer.cs
@@ -19,7 +19,7 @@ namespace Rock.DependencyInjection
     {
         private const Func<object> _getInstanceFuncNotFound = null;
 
-        private static readonly Semimutable<IResolverConstructorSelector> _defaultResolverConstructorSelector = new Semimutable<IResolverConstructorSelector>(GetDefaultDefaultResolverConstructorSelector, true);
+        private static readonly Semimutable<IResolverConstructorSelector> _defaultResolverConstructorSelector = new Semimutable<IResolverConstructorSelector>(GetDefaultDefaultResolverConstructorSelector);
 
         private static readonly MethodInfo _genericGetMethod;
 

--- a/Rock.Core/DependencyInjection/AutoContainer.cs
+++ b/Rock.Core/DependencyInjection/AutoContainer.cs
@@ -131,7 +131,7 @@ namespace Rock.DependencyInjection
 
         internal static void UnlockDefaultResolverConstructorSelector()
         {
-            _defaultResolverConstructorSelector.UnlockValue();
+            _defaultResolverConstructorSelector.GetUnlockValueMethod().Invoke(_defaultResolverConstructorSelector, null);
         }
 
         private static IResolverConstructorSelector GetDefaultDefaultResolverConstructorSelector()

--- a/Rock.Core/IO/TempStorage.cs
+++ b/Rock.Core/IO/TempStorage.cs
@@ -29,7 +29,7 @@ namespace Rock.IO
 
         internal static void UnlockKeyValueStore()
         {
-            _keyValueStore.UnlockValue();
+            _keyValueStore.GetUnlockValueMethod().Invoke(_keyValueStore, null);
         }
 
         private static IKeyValueStore GetDefaultKeyValueStore()

--- a/Rock.Core/IO/TempStorage.cs
+++ b/Rock.Core/IO/TempStorage.cs
@@ -9,7 +9,7 @@ namespace Rock.IO
 {
     public static class TempStorage
     {
-        private static readonly Semimutable<IKeyValueStore> _keyValueStore = new Semimutable<IKeyValueStore>(GetDefaultKeyValueStore, true);
+        private static readonly Semimutable<IKeyValueStore> _keyValueStore = new Semimutable<IKeyValueStore>(GetDefaultKeyValueStore);
 
         public static IKeyValueStore KeyValueStore
         {

--- a/Rock.Core/Reflection/IsPrimitivishExtension.cs
+++ b/Rock.Core/Reflection/IsPrimitivishExtension.cs
@@ -7,7 +7,7 @@ namespace Rock.Reflection
 {
     public static class IsPrimitivishExtension
     {
-        private static readonly Semimutable<IEnumerable<Type>> _extraPrimitivishTypes = new Semimutable<IEnumerable<Type>>(GetDefaultExtraPrimitiveTypes, true);
+        private static readonly Semimutable<IEnumerable<Type>> _extraPrimitivishTypes = new Semimutable<IEnumerable<Type>>(GetDefaultExtraPrimitiveTypes);
 
         internal static readonly Type[] _defaultPrimitivishTypes =
         {

--- a/Rock.Core/Reflection/IsPrimitivishExtension.cs
+++ b/Rock.Core/Reflection/IsPrimitivishExtension.cs
@@ -37,7 +37,7 @@ namespace Rock.Reflection
 
         internal static void UnlockExtraPrimitivishTypes()
         {
-            _extraPrimitivishTypes.UnlockValue();
+            _extraPrimitivishTypes.GetUnlockValueMethod().Invoke(_extraPrimitivishTypes, null);
         }
 
         private static IEnumerable<Type> GetDefaultExtraPrimitiveTypes()

--- a/RockLib.Threading.Tests/RockLib.Threading.Tests.csproj
+++ b/RockLib.Threading.Tests/RockLib.Threading.Tests.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\Rock.Core\Threading\RockLib.Threading.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Semimutable constructor no longer has canUnlock parameter, references updated
Semimutable UnlockValue method is now private, references updated to use GetUnlockValueMethod